### PR TITLE
Updated the B&A Self Serve explainer clarified B&A currently supports only amd64 architecture

### DIFF
--- a/bidding_auction_services_onboarding_self_serve_guide.md
+++ b/bidding_auction_services_onboarding_self_serve_guide.md
@@ -78,6 +78,10 @@ to one or the other.
   * [Optimize payload][32].
   * Review [logging][26].
 
+### Supported Architectures
+
+B&A currently only support amd64 (x86_64 ISA) architecture.
+
 ### Cloud platforms
 
   * Adtechs need to choose one of the currently [supported cloud platforms][27] to run


### PR DESCRIPTION
Added a note to the "Cloud Platforms" section of the B&A Self Serve explainer specifying that only the amd64 architecture (also known as x86_64) is currently supported for B&A services. 