### PR TITLE
Add co-authors to bidding_auction_cost_estimation_tool.md

### DIFF
--- a/bidding_auction_cost_estimation_tool.md
+++ b/bidding_auction_cost_estimation_tool.md
@@ -1,8 +1,10 @@
 # Bidding and Auction Cost Estimation Tool
 
 **Authors:** <br>
-[Akshay Pundle](https://github.com/akshaypundle), Google Privacy Sandbox <br>
-[Trenton Starkey](https://github.com/trentonstarkey),  Google Privacy Sandbox <br>
+[Akshay Pundle](https://github.com/akshaypundle), Google Privacy Sandbox (Emeritus) <br>
+[Trenton Starkey](https://github.com/trentonstarkey),  Google Privacy Sandbox (Emeritus) <br>
+[Mihir Gandhi](https://github.com/webmihir), Google Privacy Sandbox (Emeritus) <br>
+[Ashish Bhardwaj](https://github.com/ashishbhardwaj0), Google Privacy Sandbox (Emeritus) <br>
 
 ## Overview
 


### PR DESCRIPTION
We had earlier missed adding Ashish and Mihir as co-authors for the cost estimation tool; so retroactively adding them.